### PR TITLE
매칭 기능 구현

### DIFF
--- a/application/teamplay-external-api/src/main/kotlin/com/teamplay/api/external/controller/MatchController.kt
+++ b/application/teamplay-external-api/src/main/kotlin/com/teamplay/api/external/controller/MatchController.kt
@@ -1,44 +1,54 @@
 package com.teamplay.api.com.teamplay.api.external.controller
 
+import com.teamplay.api.com.teamplay.api.external.config.baseUrl
+import com.teamplay.api.com.teamplay.api.external.response.MatchScheduleResponse
+import com.teamplay.api.com.teamplay.api.external.service.MatchService
+import com.teamplay.domain.database.jpa.match.repository.spec.MatchSpecs
+import com.teamplay.domain.database.match.entity.Match
+import com.teamplay.domain.database.match.entity.MatchRequest
 import io.swagger.annotations.ApiOperation
+import org.springframework.data.domain.Page
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping("/matches")
-class MatchController {
+@RequestMapping("$baseUrl/matches")
+class MatchController (
+        private val matchService: MatchService
+) {
 
-    @ApiOperation(value = "매칭 게시글 전체 보기")
+    @ApiOperation(value = "매칭 게시글 보기")
     @GetMapping
-    fun find(): String {
-        //페이징 처리하여 보여줄지 논의 필요.
-        //찾기도 여기로 검색
-        //spec 정의해서
-        return "매칭 게시글 전체 보기"
+    fun find(@ModelAttribute specs: MatchSpecs): Page<Match> {
+        return matchService.find(specs)
     }
 
     @ApiOperation(value = "매칭 상세 글 보기")
-    @GetMapping("/{id}")
-    fun get(@PathVariable id: Long): String {
-        return "매칭 상세 글 보기"
+    @GetMapping("/{matchId}")
+    fun get(@PathVariable matchId: Long): Match {
+        return matchService.get(matchId)
     }
 
-    @ApiOperation(value = "시합 요청")
-    @PostMapping("/{id}/request")
-    fun requestMatch(@PathVariable id: Long): String {
-        // 시합 요청 테이블도 만들면 좋을듯? 거기에서 신청 받을지 말지 타입으로 지정하는것도 좋을듯하네요.
-        return "시합 요청"
-    }
-
-    @ApiOperation(value = "시합 요청 응답")
-    @PutMapping("/{id}/response")
-    fun responseMatch(@PathVariable id: Long): String {
-        // 시합 요청 테이블도 만들면 좋을듯? 거기에서 신청 받을지 말지 타입으로 지정하는것도 좋을듯하네요.
-        return "시합 요청 응답"
+    @ApiOperation(value = "매칭 스케쥴 보기")
+    @GetMapping("/schedule/{clubId}")
+    fun getSchedule(@PathVariable clubId: Long): MatchScheduleResponse {
+        return matchService.getMatchSchedule(clubId)
     }
 
     @ApiOperation(value = "매칭 게시글 작성")
     @PostMapping
-    fun save(): String {
-        return "매칭 게시글 작성"
+    fun save(@RequestBody match: Match): Match {
+        return matchService.save(match)
+    }
+
+    @ApiOperation(value = "시합 요청")
+    @PostMapping("/matchRequest/{matchId}")
+    fun matchRequest(@PathVariable matchId: Long, @RequestBody matchRequest: MatchRequest): MatchRequest {
+        return matchService.saveMatchRequest(matchId, matchRequest)
+    }
+
+    @ApiOperation(value = "시합 요청 응답")
+    @PutMapping("/matchResponse")
+    fun matchResponse(@RequestBody matchRequest: MatchRequest): Match {
+        return matchService.responseMatchRequest(matchRequest)
     }
 }

--- a/application/teamplay-external-api/src/main/kotlin/com/teamplay/api/external/controller/MatchController.kt
+++ b/application/teamplay-external-api/src/main/kotlin/com/teamplay/api/external/controller/MatchController.kt
@@ -1,8 +1,8 @@
 package com.teamplay.api.com.teamplay.api.external.controller
 
 import com.teamplay.api.com.teamplay.api.external.config.baseUrl
-import com.teamplay.api.com.teamplay.api.external.response.MatchScheduleResponse
 import com.teamplay.api.com.teamplay.api.external.service.MatchService
+import com.teamplay.domain.business.match.dto.MatchScheduleResponse
 import com.teamplay.domain.database.jpa.match.repository.spec.MatchSpecs
 import com.teamplay.domain.database.match.entity.Match
 import com.teamplay.domain.database.match.entity.MatchRequest

--- a/application/teamplay-external-api/src/main/kotlin/com/teamplay/api/external/response/MatchScheduleResponse.kt
+++ b/application/teamplay-external-api/src/main/kotlin/com/teamplay/api/external/response/MatchScheduleResponse.kt
@@ -1,0 +1,11 @@
+package com.teamplay.api.com.teamplay.api.external.response
+
+import com.teamplay.domain.database.match.entity.Match
+import com.teamplay.domain.database.match.entity.MatchRequest
+
+data class MatchScheduleResponse(
+    val matchSchedule: MutableList<Match>,
+    val hostMatchRequest: MutableList<MatchRequest>,
+    val guestMatchRequest: MutableList<MatchRequest>,
+    override val message: String? = "Match Schedule"
+): Response()

--- a/application/teamplay-external-api/src/main/kotlin/com/teamplay/api/external/service/MatchService.kt
+++ b/application/teamplay-external-api/src/main/kotlin/com/teamplay/api/external/service/MatchService.kt
@@ -1,0 +1,70 @@
+package com.teamplay.api.com.teamplay.api.external.service
+
+import com.teamplay.api.com.teamplay.api.external.response.MatchScheduleResponse
+import com.teamplay.domain.database.jpa.match.repository.MatchRepository
+import com.teamplay.domain.database.jpa.match.repository.MatchRequestRepository
+import com.teamplay.domain.database.jpa.match.repository.spec.MatchSpecs
+import com.teamplay.domain.database.match.entity.Match
+import com.teamplay.domain.database.match.entity.MatchRequest
+import com.teamplay.domain.database.match.entity.MatchRequestStatus
+import com.teamplay.domain.database.match.entity.MatchStatus
+import org.springframework.data.domain.Page
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import javax.persistence.EntityManager
+
+@Service
+class MatchService (
+        private val matchRepository: MatchRepository,
+        private val matchRequestRepository: MatchRequestRepository,
+        private val entityManager: EntityManager
+) {
+    fun find(specs: MatchSpecs): Page<Match> {
+        return matchRepository.findAll(specs.createSpecs(), specs.createPageRequest())
+    }
+
+    fun get(id: Long): Match {
+        return matchRepository.getOne(id)
+    }
+
+    fun getMatchSchedule(clubId: Long): MatchScheduleResponse {
+        val matchSchedule = matchRepository.findAllAcceptMatch(clubId)
+        val hostMatchRequest = matchRequestRepository.findAllHostMatch(clubId)
+        val guestMatchRequest = matchRequestRepository.findAllGuestMatch(clubId)
+
+        return MatchScheduleResponse(
+                matchSchedule, hostMatchRequest, guestMatchRequest
+        )
+    }
+
+    @Transactional
+    fun save(match: Match): Match {
+        return matchRepository.save(match.prepareForSave())
+    }
+
+    @Transactional
+    fun saveMatchRequest(matchId: Long, matchRequest: MatchRequest): MatchRequest {
+        matchRequest.match = get(matchId)
+        return entityManager.merge(matchRequest)
+    }
+
+    @Transactional
+    fun responseMatchRequest(matchRequest: MatchRequest): Match {
+        return matchRepository.getByMatchRequests(matchRequest).let { match ->
+            if (matchRequest.matchRequestStatus == MatchRequestStatus.ACCEPT) {
+                match.matchStatus = MatchStatus.CLOSE
+
+                match.matchRequests?.map{
+                    if (it.id != matchRequest.id) {
+                        it.matchRequestStatus = MatchRequestStatus.REJECT
+                    }
+                }
+            }
+            match.matchRequests?.indexOf(matchRequest)?.let {
+                match.matchRequests!!.set(it, matchRequest)
+            }
+
+            save(match)
+        }
+    }
+}

--- a/core/function-core/src/main/kotlin/com/teamplay/core/function/error/InvalidSpecError.kt
+++ b/core/function-core/src/main/kotlin/com/teamplay/core/function/error/InvalidSpecError.kt
@@ -1,0 +1,3 @@
+package com.teamplay.core.function.error
+
+open class InvalidSpecError(message: String = "Invalid Spec Error") : Error(message)

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/dto/MatchScheduleResponse.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/dto/MatchScheduleResponse.kt
@@ -1,4 +1,4 @@
-package com.teamplay.api.com.teamplay.api.external.response
+package com.teamplay.domain.business.match.dto
 
 import com.teamplay.domain.database.match.entity.Match
 import com.teamplay.domain.database.match.entity.MatchRequest
@@ -6,6 +6,5 @@ import com.teamplay.domain.database.match.entity.MatchRequest
 data class MatchScheduleResponse(
     val matchSchedule: MutableList<Match>,
     val hostMatchRequest: MutableList<MatchRequest>,
-    val guestMatchRequest: MutableList<MatchRequest>,
-    override val message: String? = "Match Schedule"
-): Response()
+    val guestMatchRequest: MutableList<MatchRequest>
+)

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/error/MatchIsNotExistError.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/error/MatchIsNotExistError.kt
@@ -1,0 +1,6 @@
+package com.teamplay.domain.business.match.error
+
+import com.teamplay.core.function.error.NotFoundError
+
+class MatchIsNotExistError(message: String = "match is not exist") : NotFoundError(message)
+

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/error/MatchRequestIsNotExistError.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/error/MatchRequestIsNotExistError.kt
@@ -1,0 +1,6 @@
+package com.teamplay.domain.business.match.error
+
+import com.teamplay.core.function.error.NotFoundError
+
+class MatchRequestIsNotExistError(message: String = "match request is not exist") : NotFoundError(message)
+

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/FindAllMatchByMatchSpec.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/FindAllMatchByMatchSpec.kt
@@ -1,0 +1,17 @@
+package com.teamplay.domain.business.match.function
+
+import com.teamplay.core.function.Function
+import com.teamplay.domain.database.jpa.match.repository.MatchRepository
+import com.teamplay.domain.database.jpa.match.repository.spec.MatchSpecs
+import com.teamplay.domain.database.match.entity.Match
+import org.springframework.data.domain.Page
+
+class FindAllMatchByMatchSpec(
+    private val matchRepository: MatchRepository
+): Function<MatchSpecs, Page<Match>> {
+    override fun apply(specs: MatchSpecs): Page<Match> {
+
+        return matchRepository.findAll(specs.createSpecs(), specs.createPageRequest())
+    }
+
+}

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/GetMatchById.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/GetMatchById.kt
@@ -1,0 +1,15 @@
+package com.teamplay.domain.business.match.function
+
+import com.teamplay.core.function.Function
+import com.teamplay.domain.database.jpa.match.repository.MatchRepository
+import com.teamplay.domain.database.match.entity.Match
+
+class GetMatchById(
+    private val matchRepository: MatchRepository
+): Function<Long, Match> {
+    override fun apply(id: Long): Match {
+
+        return matchRepository.findById(id).get()
+    }
+
+}

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/GetMatchScheduleByClubId.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/GetMatchScheduleByClubId.kt
@@ -1,0 +1,22 @@
+package com.teamplay.domain.business.match.function
+
+import com.teamplay.core.function.Function
+import com.teamplay.domain.business.match.dto.MatchScheduleResponse
+import com.teamplay.domain.database.jpa.match.repository.MatchRepository
+import com.teamplay.domain.database.jpa.match.repository.MatchRequestRepository
+
+class GetMatchScheduleByClubId(
+    private val matchRepository: MatchRepository,
+    private val matchRequestRepository: MatchRequestRepository
+): Function<Long, MatchScheduleResponse> {
+    override fun apply(id: Long): MatchScheduleResponse {
+        val matchSchedule = matchRepository.findAllAcceptMatch(id)
+        val hostMatchRequest = matchRequestRepository.findAllHostMatch(id)
+        val guestMatchRequest = matchRequestRepository.findAllGuestMatch(id)
+
+        return MatchScheduleResponse(
+                matchSchedule, hostMatchRequest, guestMatchRequest
+        )
+    }
+
+}

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/SaveMatch.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/SaveMatch.kt
@@ -1,0 +1,16 @@
+package com.teamplay.domain.business.match.function
+
+import com.teamplay.core.function.Function
+import com.teamplay.domain.database.jpa.match.repository.MatchRepository
+import com.teamplay.domain.database.match.entity.Match
+import org.springframework.transaction.annotation.Transactional
+
+open class SaveMatch(
+    private val matchRepository: MatchRepository
+): Function<Match, Match> {
+    @Transactional
+    override fun apply(match: Match): Match {
+        return matchRepository.save(match.prepareForSave())
+    }
+
+}

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/UpdateMatchRequest.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/function/UpdateMatchRequest.kt
@@ -1,0 +1,34 @@
+package com.teamplay.domain.business.match.function
+
+import com.teamplay.core.function.Function
+import com.teamplay.domain.database.jpa.match.repository.MatchRepository
+import com.teamplay.domain.database.match.entity.Match
+import com.teamplay.domain.database.match.entity.MatchRequest
+import com.teamplay.domain.database.match.entity.MatchRequestStatus
+import com.teamplay.domain.database.match.entity.MatchStatus
+import org.springframework.transaction.annotation.Transactional
+
+open class UpdateMatchRequest(
+    private val matchRepository: MatchRepository
+): Function<MatchRequest, Match> {
+    @Transactional
+    override fun apply(matchRequest: MatchRequest): Match {
+        return matchRepository.getByMatchRequests(matchRequest).let { match ->
+            if (matchRequest.matchRequestStatus == MatchRequestStatus.ACCEPT) {
+                match.matchStatus = MatchStatus.CLOSE
+
+                match.matchRequests?.map{
+                    if (it.id != matchRequest.id) {
+                        it.matchRequestStatus = MatchRequestStatus.REJECT
+                    }
+                }
+            }
+            match.matchRequests?.indexOf(matchRequest)?.let {
+                match.matchRequests!!.set(it, matchRequest)
+            }
+
+            match
+        }
+    }
+
+}

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/validator/CheckExistMatchById.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/validator/CheckExistMatchById.kt
@@ -1,0 +1,14 @@
+package com.teamplay.domain.business.match.validator
+
+import com.teamplay.core.function.ValidatorWithError
+import com.teamplay.domain.business.match.error.MatchIsNotExistError
+import com.teamplay.domain.database.jpa.match.repository.MatchRepository
+
+class CheckExistMatchById(
+    private val repository: MatchRepository
+): ValidatorWithError<Long>(MatchIsNotExistError()) {
+
+    override fun apply(matchId: Long): Boolean {
+        return repository.existsById(matchId)
+    }
+}

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/validator/CheckExistMatchRequest.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/validator/CheckExistMatchRequest.kt
@@ -1,0 +1,14 @@
+package com.teamplay.domain.business.match.validator
+
+import com.teamplay.core.function.ValidatorWithError
+import com.teamplay.domain.business.match.error.MatchRequestIsNotExistError
+import com.teamplay.domain.database.jpa.match.repository.MatchRequestRepository
+
+class CheckExistMatchRequest(
+    private val repository: MatchRequestRepository
+): ValidatorWithError<Long>(MatchRequestIsNotExistError()) {
+
+    override fun apply(matchRequestId: Long): Boolean {
+        return repository.existsById(matchRequestId)
+    }
+}

--- a/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/validator/CheckValidMatchSpec.kt
+++ b/domain/teamplay-business-domain/src/main/kotlin/com/teamplay/domain/business/match/validator/CheckValidMatchSpec.kt
@@ -1,0 +1,20 @@
+package com.teamplay.domain.business.match.validator
+
+import com.teamplay.core.function.ValidatorWithError
+import com.teamplay.core.function.error.InvalidSpecError
+import com.teamplay.domain.database.jpa.match.repository.spec.MatchSpecs
+import com.teamplay.domain.database.match.entity.Match
+
+class CheckValidMatchSpec: ValidatorWithError<MatchSpecs>(InvalidSpecError()) {
+    override fun apply(matchSpecs: MatchSpecs): Boolean {
+        val camelRegex = "(?<=[a-zA-Z])[A-Z]".toRegex()
+
+        return matchSpecs.let {it.page > 0 && it.rowsPerPage > 0 && Match::class.java.declaredFields.map { field ->
+                camelRegex.replace(field.name) { column ->
+                    "_${column.value}"
+                }.toLowerCase()
+            }.contains(it.sortBy)
+        }
+    }
+
+}

--- a/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/club/entity/Club.kt
+++ b/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/club/entity/Club.kt
@@ -43,5 +43,8 @@ data class Club(
     var updatedDate: Date? = null,
 
     @OneToMany(mappedBy = "club")
-    var members: MutableList<ClubMember> = mutableListOf<ClubMember>()
+    var members: MutableList<ClubMember> = mutableListOf(),
+
+    @OneToMany(mappedBy = "club")
+    var admins: MutableList<ClubAdmin> = mutableListOf()
 ): EntityId

--- a/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/Match.kt
+++ b/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/Match.kt
@@ -14,7 +14,6 @@ data class Match(
     override val id: Long?,
 
     @OneToOne
-    @Column(nullable = false)
     val home: Club,
 
     @OneToOne

--- a/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/Match.kt
+++ b/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/Match.kt
@@ -5,7 +5,6 @@ import com.teamplay.domain.database.club.entity.Club
 import org.hibernate.annotations.CreationTimestamp
 import java.util.*
 import javax.persistence.*
-import kotlin.random.Random
 
 @Entity
 @Table(name = "matches")
@@ -15,28 +14,47 @@ data class Match(
     override val id: Long?,
 
     @OneToOne
-    @JoinColumn(name = "home_id")
-    var home: Club? = null,
+    @Column(nullable = false)
+    val home: Club,
 
     @OneToOne
-    @JoinColumn(name = "away_id")
-    var away: Club? = null,
+    val away: Club? = null,
 
-    var location: String,
+    @Column(nullable = false)
+    val location: String,
 
-    var startTime: Date,
+    @Column(nullable = false)
+    val startTime: Date,
 
-    var endTime: Date,
+    @Column(nullable = false)
+    val endTime: Date,
 
-    var homeScore: Int,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val matchStyle: MatchStyle,
 
-    var awayScore: Int,
+    val homeScore: Int? = null,
+
+    val awayScore: Int? = null,
+
+    @Enumerated(EnumType.STRING)
+    var matchStatus: MatchStatus = MatchStatus.WAITING,
+
+    @OneToMany(mappedBy = "match", cascade = [CascadeType.PERSIST, CascadeType.MERGE])
+    val matchRequests: MutableList<MatchRequest>? = mutableListOf(),
 
     @OneToOne
     @JoinColumn(name = "winner_id")
-    var winner: Club? = null,
+    val winner: Club? = null,
 
     @CreationTimestamp
-    @Column(nullable = false)
-    val createdDate: Date
-): EntityId
+    val createdDate: Date? = Date(),
+
+    @CreationTimestamp
+    val modifiedDate: Date? = Date()
+): EntityId {
+    fun prepareForSave(): Match {
+        this.matchRequests?.forEach { it.match = this }
+        return this
+    }
+}

--- a/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchRequest.kt
+++ b/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchRequest.kt
@@ -15,7 +15,6 @@ data class MatchRequest(
     override val id: Long?,
 
     @OneToOne
-    @Column(nullable = false)
     val requester: Club,
 
     @Enumerated(EnumType.STRING)

--- a/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchRequest.kt
+++ b/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchRequest.kt
@@ -1,7 +1,10 @@
 package com.teamplay.domain.database.match.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.teamplay.core.database.EntityId
 import com.teamplay.domain.database.club.entity.Club
+import org.hibernate.annotations.CreationTimestamp
+import java.util.*
 import javax.persistence.*
 
 @Entity
@@ -12,10 +15,22 @@ data class MatchRequest(
     override val id: Long?,
 
     @OneToOne
-    @JoinColumn(name = "match_id")
-    var match: Match,
+    @Column(nullable = false)
+    val requester: Club,
 
-    @OneToOne
-    @JoinColumn(name = "requester_id")
-    var requester: Club
-    ): EntityId
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var matchRequestStatus: MatchRequestStatus = MatchRequestStatus.WAITING,
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    val createdDate: Date? = Date(),
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    val modifiedDate: Date? = Date()
+): EntityId {
+    @JsonIgnore
+    @ManyToOne
+    lateinit var match: Match
+}

--- a/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchRequestStatus.kt
+++ b/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchRequestStatus.kt
@@ -1,0 +1,5 @@
+package com.teamplay.domain.database.match.entity
+
+enum class MatchRequestStatus {
+    WAITING, REJECT, ACCEPT
+}

--- a/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchStatus.kt
+++ b/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchStatus.kt
@@ -1,0 +1,5 @@
+package com.teamplay.domain.database.match.entity
+
+enum class MatchStatus {
+    WAITING, CLOSE, END
+}

--- a/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchStyle.kt
+++ b/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/match/entity/MatchStyle.kt
@@ -1,0 +1,5 @@
+package com.teamplay.domain.database.match.entity
+
+enum class MatchStyle {
+    THREE_HALF_COURT, FIVE_HALF_COURT, THREE_FULL_COURT, FIVE_FULL_COURT
+}

--- a/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/user/entity/User.kt
+++ b/domain/teamplay-database-domain/src/main/kotlin/com/teamplay/domain/database/user/entity/User.kt
@@ -48,6 +48,6 @@ data class User(
     var updatedDate: Date? = null,
 
     @OneToMany(mappedBy = "user")
-    var clubs: MutableList<ClubMember> = mutableListOf<ClubMember>()
+    var clubs: MutableList<ClubMember> = mutableListOf()
 
 ): EntityId

--- a/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/MatchRepository.kt
+++ b/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/MatchRepository.kt
@@ -1,0 +1,23 @@
+package com.teamplay.domain.database.jpa.match.repository
+
+import com.teamplay.domain.database.match.entity.Match
+import com.teamplay.domain.database.match.entity.MatchRequest
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MatchRepository : JpaRepository<Match, Long>, JpaSpecificationExecutor<Match> {
+    fun getByMatchRequests(matchRequest: MatchRequest): Match
+
+    @Query("""
+        SELECT m 
+        from Match m 
+        WHERE m.matchStatus = com.teamplay.domain.database.match.entity.MatchRequestStatus.ACCEPT
+        AND m.home = :homeClub
+        AND m.startTime > sysdate - 30/(24*60)
+        ORDER BY m.startTime DESC
+    """)
+    fun findAllAcceptMatch(homeClub: Long): MutableList<Match>
+}

--- a/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/MatchRepository.kt
+++ b/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/MatchRepository.kt
@@ -16,7 +16,7 @@ interface MatchRepository : JpaRepository<Match, Long>, JpaSpecificationExecutor
         from Match m 
         WHERE m.matchStatus = com.teamplay.domain.database.match.entity.MatchRequestStatus.ACCEPT
         AND m.home = :homeClub
-        AND m.startTime > sysdate - 30/(24*60)
+        AND m.startTime BETWEEN CURRENT_DATE AND sysdate + 30/(24*60)
         ORDER BY m.startTime DESC
     """)
     fun findAllAcceptMatch(homeClub: Long): MutableList<Match>

--- a/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/MatchRequestRepository.kt
+++ b/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/MatchRequestRepository.kt
@@ -12,7 +12,7 @@ interface MatchRequestRepository : JpaRepository<MatchRequest, Long> {
         from MatchRequest mr
         WHERE mr.match.home = :club
         AND mr.matchRequestStatus = com.teamplay.domain.database.match.entity.MatchRequestStatus.WAITING
-        AND mr.createdDate > sysdate - 30/(24*60)
+        AND mr.match.startTime > CURRENT_DATE
     """)
     fun findAllHostMatch(club: Long): MutableList<MatchRequest>
 
@@ -20,7 +20,7 @@ interface MatchRequestRepository : JpaRepository<MatchRequest, Long> {
         SELECT mr
         from MatchRequest mr
         WHERE mr.requester = :club
-        AND mr.createdDate > sysdate - 30/(24*60)
+        AND mr.match.startTime > CURRENT_DATE
     """)
     fun findAllGuestMatch(club: Long): MutableList<MatchRequest>
 }

--- a/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/MatchRequestRepository.kt
+++ b/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/MatchRequestRepository.kt
@@ -1,0 +1,26 @@
+package com.teamplay.domain.database.jpa.match.repository
+
+import com.teamplay.domain.database.match.entity.MatchRequest
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MatchRequestRepository : JpaRepository<MatchRequest, Long> {
+    @Query("""
+        SELECT mr
+        from MatchRequest mr
+        WHERE mr.match.home = :club
+        AND mr.matchRequestStatus = com.teamplay.domain.database.match.entity.MatchRequestStatus.WAITING
+        AND mr.createdDate > sysdate - 30/(24*60)
+    """)
+    fun findAllHostMatch(club: Long): MutableList<MatchRequest>
+
+    @Query("""
+        SELECT mr
+        from MatchRequest mr
+        WHERE mr.requester = :club
+        AND mr.createdDate > sysdate - 30/(24*60)
+    """)
+    fun findAllGuestMatch(club: Long): MutableList<MatchRequest>
+}

--- a/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/spec/MatchSpecs.kt
+++ b/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/match/repository/spec/MatchSpecs.kt
@@ -1,0 +1,41 @@
+package com.teamplay.domain.database.jpa.match.repository.spec
+
+import com.teamplay.domain.database.jpa.spec.PagingModel
+import com.teamplay.domain.database.match.entity.Match
+import com.teamplay.domain.database.match.entity.MatchStyle
+import org.springframework.data.jpa.domain.Specification
+import java.util.*
+import javax.persistence.criteria.Predicate
+
+data class MatchSpecs(
+        override val descending: Boolean = false,
+        override val page: Int = 1,
+        override val rowsPerPage: Int = 10,
+        override val sortBy: String? = "createdDate",
+        override val isAll: Boolean = false,
+
+        val startTime: Date? = null,
+        val location: String? = null,
+        val matchStyle: MatchStyle? = null
+) : PagingModel() {
+    fun createSpecs(): Specification<Match>? {
+        return Specification { match, _, builder ->
+
+            val predicates = mutableListOf<Predicate>(builder.conjunction())
+
+            startTime?.let {
+                predicates.add(builder.equal(match.get<Date>("startTime"), it))
+            }
+
+            location?.let {
+                predicates.add(builder.equal(match.get<String>("location"), it))
+            }
+
+            matchStyle?.let {
+                predicates.add(builder.equal(match.get<MatchStyle>("matchStyle"), it))
+            }
+
+            builder.and(*predicates.toTypedArray())
+        }
+    }
+}

--- a/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/spec/PagingModel.kt
+++ b/domain/teamplay-database-jpa-domain/src/main/kotlin/com/teamplay/domain/database/jpa/spec/PagingModel.kt
@@ -1,0 +1,21 @@
+package com.teamplay.domain.database.jpa.spec
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+
+abstract class PagingModel {
+    abstract val descending: Boolean
+    abstract val page: Int
+    abstract val rowsPerPage: Int
+    abstract val sortBy: String?
+    abstract val isAll: Boolean
+
+    fun createPageRequest(): Pageable {
+        return PageRequest.of(
+                if (this.isAll) 0 else this.page - 1,
+                if (this.isAll) Int.MAX_VALUE else this.rowsPerPage,
+                Sort.by(if (this.descending) Sort.Direction.DESC else Sort.Direction.ASC, sortBy ?: "id")
+        )
+    }
+}


### PR DESCRIPTION
기능 구현 목록

* 매칭 게시글 pagenation
* 매칭 게시글 작성
* 매칭 상세 글 보기
* 시합 요청
* 시합 요청 응답
* 매칭 스케쥴 보기

현재 개발에 삭제 / 수정이 없어서 추후 기능이 필요하게 되면 그때 구현하겠습니다.
삭제가 추가 될 경우 isDelete 로 처리할 예정입니다.

매칭 생성, 수정, 삭제 모두 save 를 통해서 할 예정이며, api crud 만 뚫을 예정입니다.

개인적으로 매칭 요청을 거절 또는 수락 할 때
matchRequestId, matchRequestStatus 를 따로 인자를 받아서 받은 값으로 update 하는 방법보다는 match 면 match, matchRequest 면 matchRequest 가 변하는 그 엔티티 자체를 가지고 생성, 수정, 삭제를 하는게 좋다고 생각합니다. 이렇게 하면 entity 대부분 컬럼을 val 로 변경하고 서버에서 변경하는 일은 거의 없게 됩니다. client 에서는 DTO를 그대로 가지고 있기에 생성, 수정, 삭제(isDelete로 처리 시)를 같은 save 를 통해 처리 할 수 있습니다.

TODO - 시합 결과 업데이트 기능 구현